### PR TITLE
fix: add safe directory in gitconfig

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,8 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 detect-secrets --version
 
+git config --global --add safe.directory /github/workspace
+
 detect-secrets scan ${INPUT_DETECT_SECRETS_FLAGS} ${INPUT_WORKDIR} \
     | baseline2rdf \
     | reviewdog -f=rdjson \


### PR DESCRIPTION
Hello 

We're facing in all our repositories some issues executing this action 

It ends with success state but printing this error 

```
fatal: detected dubious ownership in repository at '/github/workspace'
```

The error happens in both public ubuntu and self-hosted runners 

<img width="516" alt="image" src="https://user-images.githubusercontent.com/50871378/215714694-ad5922c4-d8ed-4f32-9040-3d57c530cc15.png">

The **behavior of this is that everything is ok on workflows**, no secrets are detected and so users can thought no secrets are stored in the repository