### PR TITLE
fix(detect-scan): support input for `.secrets.baseline` path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Optional. Additional reviewdog flags.
 Optional. Flags and args of detect-secrets command.
 The default is `--all-files --force-use-all-plugins`.
 
+### `baseline_path`
+
+Optional. The path to provide to `--baseline` argument of detect-secrets command.
+If provided, the baseline file will be updated with newly discovered secrets, otherwise it will be created.
+The default is empty, so baseline created or overwritten.
+
 ## Example usage
 
 ### [.github/workflows/reviewdog.yml](.github/workflows/reviewdog.yml)

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
   detect_secrets_flags:
     description: Flags and args of detect-secrets command. The default is '--all-files --force-use-all-plugins'.
     default: --all-files --force-use-all-plugins
+  baseline_path:
+    description: The baseline path to update. If not provided, a new baseline will be created.
+    default: ""
 runs:
   using: docker
   image: Dockerfile

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,7 @@ git config --global --add safe.directory /github/workspace
 if [ -n "${INPUT_BASELINE_PATH}" ]; then
     # When .secrets.baseline is provided, the file is only updated and not written to stdout
     detect-secrets scan ${INPUT_DETECT_SECRETS_FLAGS} --baseline ${INPUT_BASELINE_PATH} ${INPUT_WORKDIR}
+    mv ${INPUT_BASELINE_PATH} .secrets.baseline
 else
     detect-secrets scan ${INPUT_DETECT_SECRETS_FLAGS} ${INPUT_WORKDIR} > .secrets.baseline
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,14 @@ detect-secrets --version
 
 git config --global --add safe.directory /github/workspace
 
-detect-secrets scan ${INPUT_DETECT_SECRETS_FLAGS} ${INPUT_WORKDIR} \
-    | baseline2rdf \
+if [ -n "${INPUT_BASELINE_PATH}" ]; then
+    # When .secrets.baseline is provided, the file is only updated and not written to stdout
+    detect-secrets scan ${INPUT_DETECT_SECRETS_FLAGS} --baseline ${INPUT_BASELINE_PATH} ${INPUT_WORKDIR}
+else
+    detect-secrets scan ${INPUT_DETECT_SECRETS_FLAGS} ${INPUT_WORKDIR} > .secrets.baseline
+fi
+
+echo .secrets.baseline | baseline2rdf \
     | reviewdog -f=rdjson \
         -name="${INPUT_NAME:-detect-secrets}" \
         -filter-mode="${INPUT_FILTER_MODE:-added}" \


### PR DESCRIPTION
# Issue
When `.secrets.baseline` is provided, the file is only updated and not written to stdout.
Therefore, the pipe to `baseline2rdf` doesn't work as there is no JSON to parse.

# Proposed solution
- Add an input to specify a baseline path (usually `.secrets.baseline`).
- If an input is provided, just update the current baseline file (rename to conventional name if different). If not, output the json from stdout to `.secrets.baseline`
- Echo the content of `.secrets.baseline` and pipe it to `baseline2rdf` and `reviewdog` commands.