### PR TITLE
feat(action): add `skip_audited` and `verbose` options to `baseline2rdf`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,12 @@ inputs:
   baseline_path:
     description: The baseline path to update. If not provided, a new baseline will be created.
     default: ""
+  skip_audited:
+    description: Whether to skip secrets that have been audited. [true,false]
+    default: "false"
+  verbose:
+    description: Whether to print verbose output. [true,false]
+    default: "false"
 runs:
   using: docker
   image: Dockerfile

--- a/baseline2rdf.py
+++ b/baseline2rdf.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import sys
 import json
+import argparse
 
 rdjson = {
     'source': {
@@ -13,7 +14,7 @@ rdjson = {
 }
 
 
-def main():
+def main(skip_audited: bool = False, verbose: bool = False):
     baseline = json.load(sys.stdin)
     if not baseline['results']:
         baseline['results'] = {}
@@ -21,21 +22,25 @@ def main():
     results = {}
     for detects in baseline['results'].values():
         for item in detects:
-            key = '%s:%s' % (item['filename'], item['line_number'])
-            if key in results:
-                results[key]['message'] += '\n* ' + item['type']
+            if skip_audited and 'is_secret' in item and not item['is_secret']:
+                if verbose:
+                    print('Skipping verified secret in : %s' % item['filename'])
             else:
-                results[key] = {
-                    'message': '\n* ' + item['type'],
-                    'location': {
-                        'path': item['filename'],
-                        'range': {
-                            'start': {
-                                'line': item['line_number']
+                key = '%s:%s' % (item['filename'], item['line_number'])
+                if key in results:
+                    results[key]['message'] += '\n* ' + item['type']
+                else:
+                    results[key] = {
+                        'message': '\n* ' + item['type'],
+                        'location': {
+                            'path': item['filename'],
+                            'range': {
+                                'start': {
+                                    'line': item['line_number']
+                                }
                             }
                         }
                     }
-                }
 
     for result in results.values():
         rdjson['diagnostics'].append(result)
@@ -50,4 +55,12 @@ def main():
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--skip-audited', dest='skip_audited', action='store_true')
+    parser.add_argument('--no-skip-audited', dest='skip_audited', action='store_false')
+    parser.set_defaults(skip_audited=False)
+    parser.add_argument('--verbose', dest='verbose', action='store_true')
+    parser.set_defaults(verbose=False)
+    args = parser.parse_args()
+
+    sys.exit(main(skip_audited=args.skip_audited, verbose=args.verbose))

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,14 @@ else
     detect-secrets scan ${INPUT_DETECT_SECRETS_FLAGS} ${INPUT_WORKDIR} > /tmp/.secrets.baseline
 fi
 
-cat /tmp/.secrets.baseline | baseline2rdf \
+if [ "${INPUT_SKIP_AUDITED}" = "true" ]; then
+    SKIP_AUDITED_FLAG="--skip-audited"
+fi
+if [ "${INPUT_VERBOSE}" = "true" ]; then
+    VERBOSE_FLAG="--verbose"
+fi
+
+cat /tmp/.secrets.baseline | baseline2rdf ${SKIP_AUDITED_FLAG} ${VERBOSE_FLAG} \
     | reviewdog -f=rdjson \
         -name="${INPUT_NAME:-detect-secrets}" \
         -filter-mode="${INPUT_FILTER_MODE:-added}" \


### PR DESCRIPTION
2 new optional inputs:

- `skip_audited` which will make the `baseline2rdf` script ignore detected secrets that have been previously audited acording to the `.secrets.baseline` file (audited secrets contain the field `is_secret: false`).
- `verbose`, currently only prints skipped detected secrets but can be use later on to print various information.

Feel free to provide any suggestions.
I'm still wondering if the naming of variables is correct.