### PR TITLE
Add input for setting detect-secrets version

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,3 +15,15 @@ jobs:
         github_token: ${{ secrets.github_token }}
         reporter: github-pr-review
         workdir: testdata
+
+  detect-secrets-version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: detect-secrets
+      uses: ./
+      with:
+        detect_secrets_version: "1.3.0"
+        github_token: ${{ secrets.github_token }}
+        reporter: github-pr-review
+        workdir: testdata

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,13 @@ RUN set -eux \
     && apt-get install -y --no-install-recommends \
         git \
         wget \
-    && wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION} \
-    && pip install detect-secrets[word_list]
+    && wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
+
+RUN if [ -n "$INPUT_DETECT_SECRETS_VERSION" ]; then \
+      pip install detect-secrets[word_list]=="$INPUT_DETECT_SECRETS_VERSION"; \
+    else \ 
+      pip install detect-secrets[word_list]; \
+    fi
 
 COPY baseline2rdf.py /usr/local/bin/baseline2rdf
 COPY entrypoint.sh /entrypoint.sh

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
   detect_secrets_flags:
     description: Flags and args of detect-secrets command. The default is '--all-files --force-use-all-plugins'.
     default: --all-files --force-use-all-plugins
+  detect_secrets_version:
+    description: The detect-secrets version to install. By default will install the latest version.
+    default: ""
   baseline_path:
     description: The baseline path to update. If not provided, a new baseline will be created.
     default: ""

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,8 @@ inputs:
 runs:
   using: docker
   image: Dockerfile
+  env:
+    INPUT_DETECT_SECRETS_VERSION: ${{ inputs.detect_secrets_version }}
 branding:
   icon: shield
   color: green


### PR DESCRIPTION
Since detect-secrets can emit several false positives, like the other reviewdog actions, it would help to be able to specify an explicit detect-secrets version as an input. Only option here is to install the latest which can change with a new release. Ideally, we would set a hard coded default version for detect-secrets but that may not be a change we want to implement right now.

Closes #36