### PR TITLE
Update docs with link/details to detect-secrets filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ jobs:
 Since detect-secrets can report false positives, it is likely that you will have to configure the CLI further using the `detect_secrets_flags` input to avoid this. There are [4 options to ignore potential false positives](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#filters):
 
 - [Excluding file paths](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-files)
-- [Excluding lines](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-lines)https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-lines
-- [Excluding secrets](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-secrets)https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-secrets
-- [Inlining exclude comments](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#inline-allowlisting-1)https://github.com/Yelp/detect-secrets?tab=readme-ov-file#inline-allowlisting-1
+- [Excluding lines](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-lines)
+- [Excluding secrets](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-secrets)
+- [Inlining exclude comments](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#inline-allowlisting-1)

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Optional. Additional reviewdog flags.
 
 ### `detect_secrets_flags`
 
-Optional. Flags and args of detect-secrets command.
-The default is `--all-files --force-use-all-plugins`.
+Optional. Flags and args of detect-secrets command. The default is `--all-files --force-use-all-plugins`. 
+This can be used to [exclude paths, secrets or lines to ignore false positives](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#filters).
 
 ### `baseline_path`
 
@@ -71,22 +71,13 @@ jobs:
         reporter: github-pr-review # Change reporter.
 ```
 
-## Troubleshooting
+## Configuration
 
-### False positives
+Since detect-secrets can report false positives, it is likely that you will have to configure the CLI further using the `detect_secrets_flags` input to avoid this. There are [4 options to ignore potential false positives](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#filters):
 
-It is possible to disable detection for individual lines of code in case of false positives.
-To do this, add a comment at the end of the line with text `pragma: allowlist secret`.
+- Excluding file paths
+- Excluding lines
+- Excluding secrets
+- Inlining exclude comments
 
-```yaml
-public_key: |  # pragma: allowlist secret
-    gX69YO4CvBsVjzAwYxdG
-    yDd30t5+9ez31gKATtj4
-```
-
-Or add a comment with the text `pragma: allowlist nextline secret` before the line.
-
-```ini
-# pragma: allowlist nextline secret
-public_key = gX69YO4CvBsVjzAwYxdG
-```
+Please refer to [the detect-secrets Filters section](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#filters) for more details on each.

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ jobs:
 
 ## Configuration
 
+### Preventing false positives
+
 Since detect-secrets can report false positives, it is likely that you will have to configure the CLI further using the `detect_secrets_flags` input to avoid this. There are [4 options to ignore potential false positives](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#filters):
 
-- Excluding file paths
-- Excluding lines
-- Excluding secrets
-- Inlining exclude comments
-
-Please refer to [the detect-secrets Filters section](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#filters) for more details on each.
+- [Excluding file paths](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-files)
+- [Excluding lines](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-lines)https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-lines
+- [Excluding secrets](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-secrets)https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-secrets
+- [Inlining exclude comments](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#inline-allowlisting-1)https://github.com/Yelp/detect-secrets?tab=readme-ov-file#inline-allowlisting-1

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jobs:
 
 ### Preventing false positives
 
-Since detect-secrets can report false positives, it is likely that you will have to configure the CLI further using the `detect_secrets_flags` input to avoid this. There are [4 options to ignore potential false positives](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#filters):
+Since detect-secrets can report false positives, it is likely that you will have to configure the CLI further using the `detect_secrets_flags` input to avoid this. There are [4 filtering options to ignore false positives](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#filters):
 
 - [Excluding file paths](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-files)
 - [Excluding lines](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-lines)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jobs:
 
 ### Preventing false positives
 
-Since detect-secrets can report false positives, it is likely that you will have to configure the CLI further using the `detect_secrets_flags` input to avoid this. There are [4 filtering options to ignore false positives](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#filters):
+Since the detect-secrets CLI can report false positives, it is likely you will have to configure it by using the `detect_secrets_flags` input to ignore any or use inline comments. There are [4 filtering options to ignore false positives](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#filters):
 
 - [Excluding file paths](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-files)
 - [Excluding lines](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#--exclude-lines)


### PR DESCRIPTION
It is common to run into false positives when using detect-secrets. Since we have had reported issues, it's best we call out each way to address false positives but direct users to the source: [the detect-secrets docs Filters section](https://github.com/Yelp/detect-secrets?tab=readme-ov-file#filters). This updates the dedicated section in the README to list each option with a link and with a similar callout in the `detect_secrets_flag` input docs for clarity.