### PR TITLE
Add fail_level and deduplicate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,16 @@ Optional. The directory from which to look for and run detect-secrets. Default '
 Optional. Reviewdog filter mode [added, diff_context, file, nofilter]
 It's the same as the `-filter-mode` flag of reviewdog.
 
+### `fail_level`
+
+Optional. If set to `none`, always use exit code 0 for reviewdog.
+Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+Possible values: [`none`, `any`, `info`, `warning`, `error`]
+Default is `none`.
+
 ### `fail_on_error`
 
+Deprecated, use `fail_level` instead.
 Whether reviewdog should fail when errors are found. [true,false]
 This is useful for failing CI builds in addition to adding comments when errors are found.
 It's the same as the `-fail-on-error` flag of reviewdog.

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,16 @@ inputs:
   filter_mode:
     description: Reviewdog filter mode [added, diff_context, file, nofilter]
     default: added
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
-    description: Whether reviewdog should fail when errors are found. [true,false] - This is useful for failing CI builds.
+    description: Deprecated, use `fail_level` instead. Whether reviewdog should fail when errors are found. [true,false] - This is useful for failing CI builds.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: "false"
   level:
     description: Report level for reviewdog [info,warning,error]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,6 +28,7 @@ cat /tmp/.secrets.baseline | baseline2rdf ${SKIP_AUDITED_FLAG} ${VERBOSE_FLAG} \
         -name="${INPUT_NAME:-detect-secrets}" \
         -filter-mode="${INPUT_FILTER_MODE:-added}" \
         -reporter="${INPUT_REPORTER:-github-pr-check}" \
+        -fail-level="${INPUT_FAIL_LEVEL}" \
         -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
         -level="${INPUT_LEVEL}" \
         ${INPUT_REVIEWDOG_FLAGS}


### PR DESCRIPTION
In https://github.com/reviewdog/reviewdog/pull/1854, we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`.
I apply it to this actions.