### PR TITLE
Fix grammar in github_token description

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ code review experience.
 
 ### `github_token`
 
-**Required**. Must be in form of `github_token: ${{ secrets.github_token }}`'.
+**Required**. Must be in the form of `${{ secrets.GITHUB_TOKEN }}`.
 
 ### `workdir`
 


### PR DESCRIPTION
Fixed grammar in the github_token description to use correct syntax format (GITHUB_TOKEN instead of github_token).